### PR TITLE
DEV: Tests adding new item unranked option

### DIFF
--- a/lib/acts_as_ranked_list/active_record/rank_column.rb
+++ b/lib/acts_as_ranked_list/active_record/rank_column.rb
@@ -62,6 +62,7 @@ module ActsAsRankedList #:nodoc:
               SET #{quoted_rank_column} = ORDERED_ROW_NUMBER_CTE.rn * #{step_increment} #{with_touch}
               FROM ORDERED_ROW_NUMBER_CTE
               WHERE #{caller_class.quoted_table_name}.#{caller_class.primary_key} = ORDERED_ROW_NUMBER_CTE.#{caller_class.primary_key}
+              AND #{quoted_rank_column_with_table_name} IS NOT NULL
             SQL
 
             connection.execute(sql)

--- a/spec/acts_as_ranked_list/active_record/service_spec.rb
+++ b/spec/acts_as_ranked_list/active_record/service_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 ::RSpec.describe ::ActsAsRankedList::ActiveRecord::Service do
-  # test skipped invalid
-
   describe "#current_rank" do
     context "when using a decimal column called rank" do
       let(:todo_item) { ::TodoItem.create!(title: "title", rank: 20) }
@@ -446,6 +444,21 @@
         value_after_spread = ::ActiveRecord::Base.connection.execute(sql).to_a.map { |diff| diff["diff_value"] }
         expect(value_before_spread).to eq((0..3).to_a)
         expect(value_after_spread).to eq((::TodoItem.step_increment .. ::TodoItem.step_increment * 4).step(::TodoItem.step_increment).to_a)
+      end
+    end
+
+    context "when items are not ranked" do
+      let!(:todo_item_group) do
+        ::TodoItem.with_skip_persistence do
+          4.times.each_with_index do |index|
+            ::TodoItem.create!(rank: nil)
+          end
+        end
+      end
+
+      it "ignores those items" do
+        ::TodoItem.spread_ranks
+        expect(::TodoItem.pluck(:rank).compact).to be_blank
       end
     end
   end

--- a/spec/acts_as_ranked_list/active_record/service_spec.rb
+++ b/spec/acts_as_ranked_list/active_record/service_spec.rb
@@ -35,6 +35,14 @@
         expect(todo_item.current_rank).not_to be_nil
       end
     end
+
+    context "when new items should be unranked" do
+      let(:todo_item) { ::UnrankedTodoItem.create! }
+
+      it "creates a new unranked object" do
+        expect(todo_item.current_rank).to be_nil
+      end
+    end
   end
 
   describe "#increase_rank" do

--- a/spec/support/active_record_helper.rb
+++ b/spec/support/active_record_helper.rb
@@ -46,6 +46,11 @@ class AdvancedTodoItem < ::ActiveRecord::Base
   acts_as_ranked_list column: "position", step_increment: 128, new_item_at: :highest
 end
 
+class UnrankedTodoItem < ::ActiveRecord::Base
+  self.table_name = "todo_items"
+  acts_as_ranked_list new_item_at: :unranked
+end
+
 class InvalidColumnNameTodoItem < ::ActiveRecord::Base
   acts_as_ranked_list
 end


### PR DESCRIPTION
It was possible to add an unranked new item, via class method `skip_persistence` or changing the default model `new_item_at` option. This tests the unranked `new_item_at` feature.