### PR TITLE
DEV: Adds scoping to constrain ranked items

### DIFF
--- a/lib/acts_as_ranked_list/active_record/service.rb
+++ b/lib/acts_as_ranked_list/active_record/service.rb
@@ -81,11 +81,11 @@ module ActsAsRankedList
         end
 
         def ranked_list_before_update_callback
-          nil
+          update_ranks
         end
 
         def ranked_list_after_update_callback
-          update_ranks
+          nil
         end
 
         def ranked_list_after_save_callback
@@ -115,7 +115,7 @@ module ActsAsRankedList
 
           query_count = query_count.count
 
-          if query_count == 0
+          if query_count < 1
             return
           end
 

--- a/lib/acts_as_ranked_list/active_record/service.rb
+++ b/lib/acts_as_ranked_list/active_record/service.rb
@@ -43,10 +43,10 @@ module ActsAsRankedList
       # @option user_options [Boolean] :avoid_collisions Controls avoiding rank collisions
       # @option user_options [Symbol] :new_item_at Controls where to add new items
       # @option user_options [Hash] :scopes Scopes ranked items based on a column, and optional value
-      # @option scopes [String/Integer/Boolean/Float] :<any_key> Uses passed value in column <any_key> to scope items
-      # @option scopes [Symbol] :<any_key> Uses passed value in column <any_key> to scope items, or a named scope
-      # @option scopes [Proc] :<any_key> Calls passed block's value in column <any_key> to scope items, or an anonymous scope
-      # @option scopes [NilClass] :<any_key> Scopes items to a relationship, by querying non-nil values in column <any_key> or <any_key_id>
+      #   * :any_key [String/Integer/Boolean/Float] Uses passed value in column <any_key> to scope items
+      #   * :any_key [Symbol] Uses passed value in column <any_key> to scope items, or a named scope
+      #   * :any_key [Proc] Calls passed block's value in column <any_key> to scope items, or an anonymous scope
+      #   * :any_key [NilClass] Scopes items to a relationship, by querying non-nil values in column <any_key> or <any_key_id>
       # @return [void]
       def acts_as_ranked_list(user_options = {})
         options = {

--- a/lib/acts_as_ranked_list/active_record/service.rb
+++ b/lib/acts_as_ranked_list/active_record/service.rb
@@ -21,7 +21,7 @@ module ActsAsRankedList
       #   class TodoItem << ::ActiveRecord::Base
       #     belongs_to :todo_list
       #     scope :recently_added, -> { where(created_at: ::Time.now - 12.hours..) }
-      #     acts_as_ranked_list scope: do # you may use as many scopes together
+      #     acts_as_ranked_list scopes: do # you may use as many scopes together
       #       column_name_one: "work", # items that have value `work` in column `column_name_one` are scoped together
       #       column_name_two: :personal, # using a symbol is overloaded, check parameters and example for more info
       #       column_name_three: 0, # this could be used to sub-rank items within a rank

--- a/spec/acts_as_ranked_list/active_record/service_spec.rb
+++ b/spec/acts_as_ranked_list/active_record/service_spec.rb
@@ -195,51 +195,189 @@
   end
 
   describe "#highest_item?" do
-    let(:todo_item_a) { ::DefaultTodoItem.create!(title: "Legend", rank: 20) }
-    let(:todo_item_b) { ::DefaultTodoItem.create!(title: "Normal", rank: 50) }
+    context "when used on an unscoped model" do
+      let(:todo_item_a) { ::DefaultTodoItem.create!(title: "Legend", rank: 20) }
+      let(:todo_item_b) { ::DefaultTodoItem.create!(title: "Normal", rank: 50) }
 
-    before do
-      ::DefaultTodoItem.delete_all
+      before do
+        ::DefaultTodoItem.delete_all
 
-      # creates todo items
-      todo_item_a
-      todo_item_b
-    end
+        # creates todo items
+        todo_item_a
+        todo_item_b
+      end
 
-    context "when used on the highest item" do
-      it "returns true" do
-        expect(todo_item_a.highest_item?).to be_truthy
+      context "when used on the highest item" do
+        it "returns true" do
+          expect(todo_item_a.highest_item?).to be_truthy
+        end
+      end
+
+      context "when used on not the highest item" do
+        it "returns false" do
+          expect(todo_item_b.highest_item?).to be_falsey
+        end
       end
     end
 
-    context "when used on not the highest item" do
-      it "returns false" do
-        expect(todo_item_b.highest_item?).to be_falsey
+    context "when used on a scoped model" do
+      before (:each) do
+        ::DefaultTodoItem.delete_all
+      end
+
+      context "when scoping on an integer column" do
+        let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+        let!(:scoped_integer_todo_item_a) { ::ScopedIntegerTodoItem.create!(scope_integer: 0, rank: 10) }
+        let!(:scoped_integer_todo_item_b) { ::ScopedIntegerTodoItem.create!(scope_integer: 500, rank: 0) }
+        let!(:scoped_integer_todo_item_c) { ::ScopedIntegerTodoItem.create!(scope_integer: 500, rank: 20) }
+
+        it "evaluates correctly" do
+          expect(scoped_integer_todo_item_a.highest_item?).to be_truthy
+          expect(scoped_integer_todo_item_b.highest_item?).to be_truthy
+          expect(scoped_integer_todo_item_c.highest_item?).to be_falsey
+          expect(todo_item.highest_item?).to be_falsey
+        end
+      end
+
+      context "when scoping on a string column" do
+        context "when using a string to define the scope" do
+          let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+          let!(:scoped_string_todo_item_a) { ::ScopedStringTodoItem.create!(scope_string: "work", rank: 10) }
+          let!(:scoped_string_todo_item_b) { ::ScopedStringTodoItem.create!(scope_string: "personal", rank: 0) }
+          let!(:scoped_string_todo_item_c) { ::ScopedStringTodoItem.create!(scope_string: "personal", rank: 20) }
+  
+          it "evaluates correctly" do
+            expect(scoped_string_todo_item_a.highest_item?).to be_truthy
+            expect(scoped_string_todo_item_b.highest_item?).to be_truthy
+            expect(scoped_string_todo_item_c.highest_item?).to be_falsey
+            expect(todo_item.highest_item?).to be_falsey
+          end
+        end
+
+        context "when using a symbol to define the scope" do
+          let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+          let!(:scoped_string_todo_item_a) { ::ScopedStringViaSymbolTodoItem.create!(scope_string: :work, rank: 10) }
+          let!(:scoped_string_todo_item_b) { ::ScopedStringViaSymbolTodoItem.create!(scope_string: :personal, rank: 0) }
+          let!(:scoped_string_todo_item_c) { ::ScopedStringViaSymbolTodoItem.create!(scope_string: :personal, rank: 20) }
+  
+          it "evaluates correctly" do
+            expect(scoped_string_todo_item_a.highest_item?).to be_truthy
+            expect(scoped_string_todo_item_b.highest_item?).to be_truthy
+            expect(scoped_string_todo_item_c.highest_item?).to be_falsey
+            expect(todo_item.highest_item?).to be_falsey
+          end
+        end
+      end
+
+      context "when scoping on multiple columns" do
+        context "when using a symbol and integer to define the scopes" do
+          let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+          let!(:scoped_multiple_todo_item_monday_a) { ::ScopedMultipleTodoItem.create!(title: "water the plants", rank: 10) }
+          let!(:scoped_multiple_todo_item_monday_b) { ::ScopedMultipleTodoItem.create!(title: "sing to the lilies", rank: 20) }
+          let!(:scoped_multiple_todo_item_tuesday_a) { ::ScopedMultipleTodoItem.create!(title: "sing to the lilies", scope_integer: :tuesday, rank: 15) }
+          let!(:scoped_multiple_todo_item_tuesday_b) { ::ScopedMultipleTodoItem.create!(title: "water the plants", scope_integer: :tuesday, rank: 22) }
+
+          it "evaluates item relative to scope" do
+            expect(scoped_multiple_todo_item_monday_a.highest_item?).to be_truthy
+            expect(scoped_multiple_todo_item_tuesday_a.highest_item?).to be_truthy
+            expect(scoped_multiple_todo_item_monday_b.highest_item?).to be_falsey
+            expect(scoped_multiple_todo_item_tuesday_b.highest_item?).to be_falsey
+          end
+        end
       end
     end
   end
 
   describe "#lowest_item?" do
-    let(:todo_item_a) { ::DefaultTodoItem.create!(title: "top", rank: 20) }
-    let(:todo_item_b) { ::DefaultTodoItem.create!(title: "bottom", rank: 50) }
+    context "when used on an unscoped model" do
+      let(:todo_item_a) { ::DefaultTodoItem.create!(title: "top", rank: 20) }
+      let(:todo_item_b) { ::DefaultTodoItem.create!(title: "bottom", rank: 50) }
 
-    before do
-      ::DefaultTodoItem.delete_all
+      before do
+        ::DefaultTodoItem.delete_all
 
-      # creates todo items
-      todo_item_a
-      todo_item_b
-    end
+        # creates todo items
+        todo_item_a
+        todo_item_b
+      end
 
-    context "when used on the lowest item" do
-      it "returns true" do
-        expect(todo_item_b.lowest_item?).to be_truthy
+      context "when used on the lowest item" do
+        it "returns true" do
+          expect(todo_item_b.lowest_item?).to be_truthy
+        end
+      end
+
+      context "when used on not the lowest item" do
+        it "returns false" do
+          expect(todo_item_a.lowest_item?).to be_falsey
+        end
       end
     end
 
-    context "when used on not the lowest item" do
-      it "returns false" do
-        expect(todo_item_a.lowest_item?).to be_falsey
+    context "when used on a scoped model" do
+      before (:each) do
+        ::DefaultTodoItem.delete_all
+      end
+
+      context "when scoping on an integer column" do
+        let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+        let!(:scoped_integer_todo_item_a) { ::ScopedIntegerTodoItem.create!(scope_integer: 0, rank: 10) }
+        let!(:scoped_integer_todo_item_b) { ::ScopedIntegerTodoItem.create!(scope_integer: 500, rank: 0) }
+        let!(:scoped_integer_todo_item_c) { ::ScopedIntegerTodoItem.create!(scope_integer: 500, rank: 20) }
+
+        it "evaluates correctly" do
+          expect(scoped_integer_todo_item_a.lowest_item?).to be_truthy
+          expect(scoped_integer_todo_item_b.lowest_item?).to be_falsey
+          expect(scoped_integer_todo_item_c.lowest_item?).to be_truthy
+          expect(todo_item.lowest_item?).to be_falsey
+        end
+      end
+
+      context "when scoping on a string column" do
+        context "when using a string to define the scope" do
+          let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+          let!(:scoped_string_todo_item_a) { ::ScopedStringTodoItem.create!(scope_string: "work", rank: 10) }
+          let!(:scoped_string_todo_item_b) { ::ScopedStringTodoItem.create!(scope_string: "personal", rank: 0) }
+          let!(:scoped_string_todo_item_c) { ::ScopedStringTodoItem.create!(scope_string: "personal", rank: 20) }
+  
+          it "evaluates correctly" do
+            expect(scoped_string_todo_item_a.lowest_item?).to be_truthy
+            expect(scoped_string_todo_item_b.lowest_item?).to be_falsey
+            expect(scoped_string_todo_item_c.lowest_item?).to be_truthy
+            expect(todo_item.lowest_item?).to be_falsey
+          end
+        end
+
+        context "when using a symbol to define the scope" do
+          let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+          let!(:scoped_string_todo_item_a) { ::ScopedStringViaSymbolTodoItem.create!(scope_string: :work, rank: 10) }
+          let!(:scoped_string_todo_item_b) { ::ScopedStringViaSymbolTodoItem.create!(scope_string: :personal, rank: 0) }
+          let!(:scoped_string_todo_item_c) { ::ScopedStringViaSymbolTodoItem.create!(scope_string: :personal, rank: 20) }
+  
+          it "evaluates correctly" do
+            expect(scoped_string_todo_item_a.lowest_item?).to be_truthy
+            expect(scoped_string_todo_item_b.lowest_item?).to be_falsey
+            expect(scoped_string_todo_item_c.lowest_item?).to be_truthy
+            expect(todo_item.lowest_item?).to be_falsey
+          end
+        end
+      end
+
+      context "when scoping on multiple columns" do
+        context "when using a symbol and integer to define the scopes" do
+          let!(:todo_item) { ::DefaultTodoItem.create!(rank: 5) }
+          let!(:scoped_multiple_todo_item_monday_a) { ::ScopedMultipleTodoItem.create!(title: "water the plants", rank: 10) }
+          let!(:scoped_multiple_todo_item_monday_b) { ::ScopedMultipleTodoItem.create!(title: "sing to the lilies", rank: 20) }
+          let!(:scoped_multiple_todo_item_tuesday_a) { ::ScopedMultipleTodoItem.create!(title: "sing to the lilies", scope_integer: :tuesday, rank: 15) }
+          let!(:scoped_multiple_todo_item_tuesday_b) { ::ScopedMultipleTodoItem.create!(title: "water the plants", scope_integer: :tuesday, rank: 22) }
+
+          it "evaluates item relative to scope" do
+            expect(scoped_multiple_todo_item_monday_a.lowest_item?).to be_falsey
+            expect(scoped_multiple_todo_item_tuesday_a.lowest_item?).to be_falsey
+            expect(scoped_multiple_todo_item_monday_b.lowest_item?).to be_truthy
+            expect(scoped_multiple_todo_item_tuesday_b.lowest_item?).to be_truthy
+          end
+        end
       end
     end
   end
@@ -459,63 +597,104 @@
   end
 
   describe ".spread_ranks" do
-    before (:each) do
-      ::DefaultTodoItem.delete_all
-    end
-
-    context "when ranks are in collision" do
-      let(:now) { ::Time.now }
-      let!(:todo_item_group) do
-        4.times.map do |index|
-          ::DefaultTodoItem.create!(rank: index, updated_at: now)
-        end
+    context "when used on an unscoped class" do
+      before (:each) do
+        ::DefaultTodoItem.delete_all
       end
 
-      it "re-orders collisioned ranks by updated_at and primary_key" do
-        ::DefaultTodoItem.spread_ranks
-        expect(::DefaultTodoItem.get_highest_items(4)).to eq(todo_item_group)
-      end
-
-      it "re-orders collisioned ranks by updated_at" do
-        ::DefaultTodoItem.get_highest_items.each_with_index do |todo_item, index|
-          todo_item.update!(rank: 200, updated_at: ::Time.now + (4 - index).minute)
-        end
-        ::DefaultTodoItem.spread_ranks
-        expect(::DefaultTodoItem.get_highest_items(4)).to eq(todo_item_group.reverse)
-      end
-    end
-
-    context "when no ranks are in collision" do
-      let!(:todo_item_group) do
-        4.times.each_with_index do |index|
-          ::DefaultTodoItem.create!(rank: index)
-        end
-      end
-
-      it "spreads rank by step_increment amount" do
-        sql = <<~SQL
-          SELECT rank, (lag(rank, 0, 0) OVER (order by rank)) AS diff_value FROM todo_items
-        SQL
-        value_before_spread = ::ActiveRecord::Base.connection.execute(sql).to_a.map { |diff| diff["diff_value"] }
-        ::DefaultTodoItem.spread_ranks
-        value_after_spread = ::ActiveRecord::Base.connection.execute(sql).to_a.map { |diff| diff["diff_value"] }
-        expect(value_before_spread).to eq((0..3).to_a)
-        expect(value_after_spread).to eq((::DefaultTodoItem.step_increment .. ::DefaultTodoItem.step_increment * 4).step(::DefaultTodoItem.step_increment).to_a)
-      end
-    end
-
-    context "when items are not ranked" do
-      let!(:todo_item_group) do
-        ::DefaultTodoItem.with_skip_persistence do
-          4.times.each_with_index do |index|
-            ::DefaultTodoItem.create!(rank: nil)
+      context "when no ranks are in collision" do
+        let!(:todo_item_group) do
+          4.times.map do |index|
+            ::DefaultTodoItem.create!(rank: index)
           end
         end
+
+        it "spreads rank by rank" do
+          ::DefaultTodoItem.spread_ranks
+          expect(::DefaultTodoItem.get_highest_items(4).pluck(:id)).to eq(todo_item_group.map(&:id))
+        end
       end
 
-      it "ignores those items" do
-        ::DefaultTodoItem.spread_ranks
-        expect(::DefaultTodoItem.pluck(:rank).compact).to be_blank
+      context "when ranks are in collision" do
+        let!(:todo_item_group) do
+          ::DefaultTodoItem.with_skip_persistence do
+            4.times.each_with_index.map do |index|
+              ::DefaultTodoItem.create!(rank: 42, updated_at: ::Time.now + (4 - index).minute)
+            end
+          end
+        end
+
+        it "spreads rank by updated_at" do
+          ::DefaultTodoItem.spread_ranks
+          expect(::DefaultTodoItem.get_highest_items(4).pluck(:id)).to eq(todo_item_group.reverse.map(&:id))
+        end
+
+        it "spreads rank by step_increment amount" do
+          sql = <<~SQL
+            SELECT rank, (lag(rank, 0, 0) OVER (order by rank)) AS diff_value FROM todo_items
+          SQL
+          value_before_spread = ::ActiveRecord::Base.connection.execute(sql).to_a.map { |diff| diff["diff_value"] }
+          ::DefaultTodoItem.spread_ranks
+          value_after_spread = ::ActiveRecord::Base.connection.execute(sql).to_a.map { |diff| diff["diff_value"] }
+          expect(value_before_spread.uniq).to eq([42])
+          expect(value_after_spread).to eq((::DefaultTodoItem.step_increment .. ::DefaultTodoItem.step_increment * 4).step(::DefaultTodoItem.step_increment).to_a)
+        end
+      end
+
+      context "when items are not ranked" do
+        let!(:todo_item_group) do
+          ::DefaultTodoItem.with_skip_persistence do
+            4.times.each_with_index do |index|
+              ::DefaultTodoItem.create!(rank: nil)
+            end
+          end
+        end
+
+        it "ignores unranked items" do
+          ::DefaultTodoItem.spread_ranks
+          expect(::DefaultTodoItem.pluck(:rank).compact).to be_blank
+        end
+      end
+    end
+
+    context "when used on a scoped class" do
+      before (:each) do
+        ::DefaultTodoItem.delete_all
+      end
+
+      context "when items belong to different scopes" do
+        let!(:todo_item_group) do
+          4.times.map do |index|
+            ::ScopedMultipleTodoItem.create!(rank: index, scope_integer: index % 2)
+          end
+        end
+
+        it "spreads rank by rank" do
+          ::ScopedMultipleTodoItem.spread_ranks
+          expected_todo_items = [todo_item_group[0], todo_item_group[2], todo_item_group[1], todo_item_group[3]].map(&:id)
+          expect(::ScopedMultipleTodoItem.get_highest_items(4).pluck(:id)).to eq(expected_todo_items)
+        end
+      end
+
+      context "when scoped items are not ranked" do
+        let!(:todo_item_group_a) do
+          ::ScopedMultipleTodoItem.with_skip_persistence([DefaultTodoItem]) do
+            2.times.each_with_index do |index|
+              ::ScopedMultipleTodoItem.create!(rank: index % 2 == 0 ? 42 : nil, scope_integer: 0)
+            end
+            2.times.each_with_index do |index|
+              ::ScopedMultipleTodoItem.create!(rank: index % 2 == 0 ? 42 : nil, scope_integer: 1)
+            end
+            2.times.each_with_index do |index|
+              ::DefaultTodoItem.create!(rank: index % 2 == 0 ? 42 : nil, scope_integer: nil) # for visibility that this item is not scoped
+            end
+          end
+        end
+
+        it "ignores unranked items" do
+          ::DefaultTodoItem.spread_ranks
+          expect(::DefaultTodoItem.get_highest_items.count).to eq(3)
+        end
       end
     end
   end

--- a/spec/acts_as_ranked_list/active_record/service_spec.rb
+++ b/spec/acts_as_ranked_list/active_record/service_spec.rb
@@ -11,10 +11,10 @@
     end
 
     context "when using an integer column not called rank" do
-      let(:advanced_todo_item) { ::AdvancedTodoItem.create!(title: "advanced title", position: 20) }
+      let(:non_default_todo_item) { ::NonDefaultTodoItem.create!(title: "advanced title", position: 20) }
 
       it "gets the current rank" do
-        expect(advanced_todo_item.current_rank).to eq(20)
+        expect(non_default_todo_item.current_rank).to eq(20)
       end
     end
   end
@@ -48,7 +48,7 @@
   describe "#increase_rank" do
     before do
       ::DefaultTodoItem.delete_all
-      ::AdvancedTodoItem.delete_all
+      ::NonDefaultTodoItem.delete_all
     end
 
     context "when adding items at the bottom of the list" do
@@ -63,13 +63,13 @@
     end
 
     context "when adding items at the top of the list" do
-      let!(:advanced_todo_item_a) { ::AdvancedTodoItem.create! }
-      let!(:advanced_todo_item_b) { ::AdvancedTodoItem.create! }
+      let!(:non_default_todo_item_a) { ::NonDefaultTodoItem.create! }
+      let!(:non_default_todo_item_b) { ::NonDefaultTodoItem.create! }
 
       it "puts item higher in the list" do
-        expect(advanced_todo_item_a.current_rank < advanced_todo_item_b.current_rank).to be_falsey
-        advanced_todo_item_a.increase_rank
-        expect(advanced_todo_item_a.current_rank < advanced_todo_item_b.current_rank).to be_truthy
+        expect(non_default_todo_item_a.current_rank < non_default_todo_item_b.current_rank).to be_falsey
+        non_default_todo_item_a.increase_rank
+        expect(non_default_todo_item_a.current_rank < non_default_todo_item_b.current_rank).to be_truthy
       end
     end
 
@@ -87,7 +87,7 @@
   describe "#decrease_rank" do
     before do
       ::DefaultTodoItem.delete_all
-      ::AdvancedTodoItem.delete_all
+      ::NonDefaultTodoItem.delete_all
     end
 
     context "when adding items at the bottom of the list" do
@@ -102,13 +102,13 @@
     end
 
     context "when adding items at the top of the list" do
-      let!(:advanced_todo_item_a) { ::AdvancedTodoItem.create! }
-      let!(:advanced_todo_item_b) { ::AdvancedTodoItem.create! }
+      let!(:non_default_todo_item_a) { ::NonDefaultTodoItem.create! }
+      let!(:non_default_todo_item_b) { ::NonDefaultTodoItem.create! }
 
       it "puts item higher in the list" do
-        expect(advanced_todo_item_a.current_rank < advanced_todo_item_b.current_rank).to be_falsey
-        advanced_todo_item_b.decrease_rank
-        expect(advanced_todo_item_a.current_rank < advanced_todo_item_b.current_rank).to be_truthy
+        expect(non_default_todo_item_a.current_rank < non_default_todo_item_b.current_rank).to be_falsey
+        non_default_todo_item_b.decrease_rank
+        expect(non_default_todo_item_a.current_rank < non_default_todo_item_b.current_rank).to be_truthy
       end
     end
 
@@ -126,7 +126,7 @@
   describe ".get_highest_items" do
     before (:each) do
       ::DefaultTodoItem.delete_all
-      ::AdvancedTodoItem.delete_all
+      ::NonDefaultTodoItem.delete_all
     end
 
     context "when called without arguments" do
@@ -162,7 +162,7 @@
   describe ".get_lowest_items" do
     before (:each) do
       ::DefaultTodoItem.delete_all
-      ::AdvancedTodoItem.delete_all
+      ::NonDefaultTodoItem.delete_all
     end
 
     context "when called without arguments" do

--- a/spec/support/active_record_helper.rb
+++ b/spec/support/active_record_helper.rb
@@ -7,6 +7,9 @@ def initialize_schema
     create_table :todo_items do |t|
       t.string :title
       t.decimal :rank
+      t.string :scope_string
+      t.boolean :scope_boolean
+      t.integer :scope_integer
 
       t.timestamps
     end
@@ -50,6 +53,39 @@ class UnrankedTodoItem < TodoItem
   acts_as_ranked_list new_item_at: :unranked
 end
 
+class ScopedIntegerTodoItem < TodoItem
+  acts_as_ranked_list scopes: { scope_integer: 0 }
+end
+
+class ScopedStringTodoItem < TodoItem
+  acts_as_ranked_list scopes: { scope_string: "work" }
+end
+
+class ScopedStringPersonalTodoItem < TodoItem
+  acts_as_ranked_list scopes: { scope_string: "personal" }
+end
+
+class ScopedStringViaSymbolTodoItem < TodoItem
+  acts_as_ranked_list scopes: { scope_string: :work }
+end
+
+class ScopedBooleanTodoItem < TodoItem
+  acts_as_ranked_list scopes: { scope_boolean: true }
+end
+
+class ScopedMultipleTodoItem < TodoItem
+  enum scope_integer: {
+    monday: 0,
+    tuesday: 1
+  }
+  before_create :initialize_values
+  acts_as_ranked_list scopes: { scope_string: :gardening, scope_integer: nil }
+
+  def initialize_values
+    self.scope_string ||= :gardening
+    self.scope_integer ||= :monday
+  end
+end
 class NonDefaultTodoItem < ::ActiveRecord::Base
   acts_as_ranked_list column: "position", step_increment: 128, new_item_at: :highest
 end

--- a/spec/support/active_record_helper.rb
+++ b/spec/support/active_record_helper.rb
@@ -4,12 +4,17 @@ end
 
 def initialize_schema
   ::ActiveRecord::Schema.define do
+    create_table :todo_lists do |t|
+      t.string :title
+    end
+
     create_table :todo_items do |t|
       t.string :title
       t.decimal :rank
       t.string :scope_string
       t.boolean :scope_boolean
       t.integer :scope_integer
+      t.references :todo_list
 
       t.timestamps
     end
@@ -41,8 +46,14 @@ connect_to_databse
 
 initialize_schema
 
+class TodoList < ::ActiveRecord::Base
+  has_many :todo_items
+end
+
 class TodoItem < ::ActiveRecord::Base
   abstract_class
+
+  belongs_to :todo_list
 end
 
 class DefaultTodoItem < TodoItem
@@ -86,6 +97,11 @@ class ScopedMultipleTodoItem < TodoItem
     self.scope_integer ||= :monday
   end
 end
+
+class ScopedListTodoItem < TodoItem
+  acts_as_ranked_list scopes: { todo_list: nil }
+end
+
 class NonDefaultTodoItem < ::ActiveRecord::Base
   acts_as_ranked_list column: "position", step_increment: 128, new_item_at: :highest
 end

--- a/spec/support/active_record_helper.rb
+++ b/spec/support/active_record_helper.rb
@@ -11,7 +11,7 @@ def initialize_schema
       t.timestamps
     end
 
-    create_table :advanced_todo_items do |t|
+    create_table :non_default_todo_items do |t|
       t.string :title
       t.integer :position
 
@@ -50,7 +50,7 @@ class UnrankedTodoItem < TodoItem
   acts_as_ranked_list new_item_at: :unranked
 end
 
-class AdvancedTodoItem < ::ActiveRecord::Base
+class NonDefaultTodoItem < ::ActiveRecord::Base
   acts_as_ranked_list column: "position", step_increment: 128, new_item_at: :highest
 end
 


### PR DESCRIPTION
`::ActiveRecord` models can have scopes on columns. PR adds scoping ranks to the same degree using symbols, strings, integers, custom scopes, or scopes to other models.