### PR TITLE
FIX: Individual operations respect touch on update

### DIFF
--- a/lib/acts_as_ranked_list/active_record/rank_column.rb
+++ b/lib/acts_as_ranked_list/active_record/rank_column.rb
@@ -312,7 +312,15 @@ module ActsAsRankedList #:nodoc:
           define_method :with_persistence do |items = [self], &blk|
             blk.call
 
+            item_record_timestamps = items.map do |i|
+              i.record_timestamps?
+            end
+
             items.each(&:save!) unless skip_persistence?
+
+            items.each_with_index do |i, idx|
+              i.record_timestamps = item_record_timestamps[idx]
+            end
           end
 
           define_method :pad_array do |array, value = nil, size = 2|


### PR DESCRIPTION
## What

Individual operations such as `increase_rank` did not respect the setting `touch_on_update`.

PR fixes this. Now, individual operations will skip updating timestamp records if the setting `touch_on_update` is false.